### PR TITLE
Positivity

### DIFF
--- a/benchmarks/runners/apfel_.py
+++ b/benchmarks/runners/apfel_.py
@@ -58,6 +58,18 @@ class BenchmarkProjectile(ApfelBenchmark):
         self.run([{"PTO": pto}], obs_update, ["ToyLH"])
 
 
+class BenchmarkPositivity(ApfelBenchmark):
+    update = {
+        "NCPositivityCharge": ["up", "down", "strange", "all"],
+    }
+
+    def benchmark_pto(self, pto):
+        obs_update = observables.build(
+            **(observables.default_config[pto]), update=self.update
+        )
+        self.run([{"PTO": pto}], obs_update, ["ToyLH"])
+
+
 class BenchmarkPropagatorCorrection(ApfelBenchmark):
     update = {
         "prDIS": ["NC", "CC"],
@@ -262,12 +274,17 @@ class BenchmarkICFONLL(ApfelICBenchmark):
 
 
 if __name__ == "__main__":
-    plain = BenchmarkPlain()
-    # plain.benchmark_lo()
-    # plain.benchmark_nlo()
+    # plain = BenchmarkPlain()
+    # plain.benchmark_pto(0)
+    # plain.benchmark_pto(1)
 
-    # proj = BenchmarkTMC()
-    # proj.benchmark_lo()
+    # proj = BenchmarkProjectile()
+    # proj.benchmark_pto(0)
+    # proj.benchmark_pto(1)
+
+    pos = BenchmarkPositivity()
+    pos.benchmark_pto(0)
+    pos.benchmark_pto(1)
 
     # ffns = BenchmarkICFFNS()
     # ffns.benchmark_lo()
@@ -275,8 +292,8 @@ if __name__ == "__main__":
     # fonll = BenchmarkICFONLL()
     # fonll.benchmark_nlo()
 
-    xs = BenchmarkXS()
-    xs.benchmark_pto(0)
+    # xs = BenchmarkXS()
+    # xs.benchmark_pto(0)
 
 # def plain_assert_external(theory, obs, sf, yad):
 #     # APFEL has a discretization in Q2/m2

--- a/benchmarks/runners/sandbox.py
+++ b/benchmarks/runners/sandbox.py
@@ -25,11 +25,11 @@ lhapdf.pathsPrepend(
 
 class Sandbox(Runner):
 
-    #  external comparison program
+    # external comparison program
     external = "APFEL"
-    #  external = "xspace_bench"
-    #  external = "QCDNUM"
-    #  external = "void"
+    # external = "xspace_bench"
+    # external = "QCDNUM"
+    # external = "void"
 
     #  alphas_from_lhapdf = True
 
@@ -79,8 +79,8 @@ class Sandbox(Runner):
             #  "XSNUTEVCC_charm"
         ]
         #update = {"prDIS": ["EM"],"interpolation_xgrid":[interpolation_xgrid], "interpolation_polynomial_degree": [4]}
-        #update = {"prDIS": ["EM"], "ProjectileDIS": ["electron"]}
-        update = {"prDIS": ["CC"], "ProjectileDIS": ["electron"]}
+        update = {"prDIS": ["EM"], "ProjectileDIS": ["electron"], "NCPositivityCharge": ["strange"]}
+        #update = {"prDIS": ["CC"], "ProjectileDIS": ["electron"]}
         #update = {"prDIS": ["EM"], "ProjectileDIS": ["electron"], "TargetDIS":["lead"]}
         #update= {}
         # card["PropagatorCorrection"] = .999
@@ -95,7 +95,8 @@ class Sandbox(Runner):
                 #{"PTO": 1, "FNS": "FFNS", "mc": 1.95, "mb": 1e6, "mt": 1e8, "NfFF": 3},
                 #{"PTO": 2, "FNS": "FFNS", "mc": 1.95, "mb": 1e6, "mt": 1e8, "NfFF": 4},
                 #{"PTO": 2, "FNS": "FONLL-C","NfFF":4,"IC":1,"mc":1.51,"Qmc":1.51,"mb":1e6,"mt":1e7,"ModEv":"TRN","MaxNfPdf":5,"MaxNfAs": 5, "Qmb":4.92,"Qmt":172.5,"alphas":0.118,"alphaqed":0.007496252,"Q0":1.65},
-                #{"PTO": 1, "FNS": "FONLL-A", "mc": 1.95, "mb": 1e6,"mt": 1e8, "NfFF": 4, "IC":0},
+                #{"PTO": 1, "FNS": "FONLL-A","IC":0},
+                {"PTO": 2, "FNS": "FONLL-C","IC":0},
                 #{"PTO": 2, "FNS": "FONLL-B", "mc": 1.51, "NfFF": 4, "kbThr": 100, "ktThr": 100, "alphas": .3, "Qref": 3},
                 #{"PTO": 2, "FNS": "FONLL-B", "mc": 1.95, "mb": 1e6, "mt": 1e8, "NfFF": 4},
                 #{"PTO": 2, "FNS": "FONLL-C", "mc": 1.95, "mb": 1e6, "mt": 1e8, "NfFF": 4},
@@ -108,20 +109,20 @@ class Sandbox(Runner):
                 #{"PTO": 1, "IC": 1, "FNS": "FONLL-A", "NfFF": 4, "mc": 1.51, "mb": 1e6, "mt": 1e8},
                 #{"PTO": 1, "IC": 1, "FNS": "FFNS", "NfFF": 3, "mc": 1.51, "XIF": 1, "XIR": 1},
                 #{"PTO": 1, "IC": 1, "FNS": "FFNS", "NfFF": 3, "mc": 1.51, "XIF": 2, "XIR": 1},
-                {"PTO": 2, "FNS": "FFNS", "mc": 1.95, "mb": 1e6, "mt": 1e8, "NfFF": 3, "XIF": 2},
+                #{"PTO": 2, "FNS": "FFNS", "mc": 1.95, "mb": 1e6, "mt": 1e8, "NfFF": 3, "XIF": 2},
             ], self.generate_observables(), [
                 # "uonly",
                 # "ubaronly",
-                # "dbaronly",
+                # "donly",
                 # "conly",
                 # "toygonly",
                 # "toyuonly",
                 # "toyantichsing",
                 # "toyt3only",
                 # "conly",
-                "ToyLH",
+                # "ToyLH",
                 # "gonly",
-                # "NNPDF31_nnlo_as_0118",
+                "NNPDF31_nnlo_as_0118",
                 # "NN31g",
                 # "NN31u",
                 # "NN31c",

--- a/src/yadism/coefficient_functions/coupling_constants.py
+++ b/src/yadism/coefficient_functions/coupling_constants.py
@@ -5,6 +5,8 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+flavors = "duscbt"
+
 
 class CouplingConstants:
     """
@@ -223,6 +225,17 @@ class CouplingConstants:
             return self.leptonic_coupling(
                 "WW", quark_coupling_type
             ) * self.partonic_coupling("WW", pid, quark_coupling_type, cc_mask=cc_mask)
+        # NC or EM
+        # are we in positivity mode?
+        if (
+            self.obs_config["nc_pos_charge"] is not None
+            and self.obs_config["nc_pos_charge"] != "all"
+        ):
+            pos = self.obs_config["nc_pos_charge"][0]
+            pos_pid = 1 + flavors.index(pos)
+            if abs(pid) != pos_pid:
+                return 0.0
+
         w_phph = (
             self.leptonic_coupling("phph", quark_coupling_type)
             * self.propagator_factor("phph", Q2)
@@ -301,6 +314,7 @@ class CouplingConstants:
             "projectilePID": projectile_pids[proj],
             "polarization": observables["PolarizationDIS"],
             "propagatorCorrection": observables["PropagatorCorrection"],
+            "nc_pos_charge": observables["NCPositivityCharge"],
         }
         o = cls(theory_config, obs_config)
         return o
@@ -376,13 +390,13 @@ class CKM2Matrix:
             return self[pid]
         return self[:, pid]
 
-    def masked(self, flavors):
+    def masked(self, flavs):
         """
         Apply a mask according to the flavor
 
         Parameters
         ----------
-            flavors : str
+            flavs : str
                 participating flavors as single characters
 
         Returns
@@ -391,13 +405,13 @@ class CKM2Matrix:
                 masked matrix
         """
         op = np.zeros((3, 3))
-        if "dus" in flavors:
+        if "dus" in flavs:
             op += np.array([[1, 1, 0], [0, 0, 0], [0, 0, 0]])
-        if "c" in flavors:
+        if "c" in flavs:
             op += np.array([[0, 0, 0], [1, 1, 0], [0, 0, 0]])
-        if "b" in flavors:
+        if "b" in flavs:
             op += np.array([[0, 0, 1], [0, 0, 1], [0, 0, 0]])
-        if "t" in flavors:
+        if "t" in flavs:
             op += np.array([[0, 0, 0], [0, 0, 0], [1, 1, 1]])
         return type(self)(self.m * op)
 

--- a/src/yadism/coefficient_functions/fonll/kernels.py
+++ b/src/yadism/coefficient_functions/fonll/kernels.py
@@ -3,6 +3,7 @@ import numpy as np
 from eko.constants import TR
 
 from .. import heavy, kernels, light
+from ..coupling_constants import flavors
 
 
 def import_pc_module(kind, process, subpkg=None):
@@ -44,7 +45,7 @@ def generate_light(esf, nl, pto_evol):
 
     if esf.process == "CC":
         light_weights = kernels.cc_weights(
-            esf.info.coupling_constants, esf.Q2, kind, kernels.flavors[:nl], nl
+            esf.info.coupling_constants, esf.Q2, kind, flavors[:nl], nl
         )
     else:
         light_weights = light.kernels.nc_weights(
@@ -115,7 +116,7 @@ def generate_light_diff(esf, nl, pto_evol):
     light_cfs = import_pc_module(kind, esf.process, "light")
     if esf.process == "CC":
         light_weights = kernels.cc_weights(
-            esf.info.coupling_constants, esf.Q2, kind, kernels.flavors[:nl], nl + 1
+            esf.info.coupling_constants, esf.Q2, kind, flavors[:nl], nl + 1
         )
     else:
         light_weights = light.kernels.nc_weights(
@@ -177,7 +178,7 @@ def generate_heavy_diff(esf, nl, pto_evol):
     asys = []
     if esf.process == "CC":
         wa = kernels.cc_weights(
-            esf.info.coupling_constants, esf.Q2, kind, kernels.flavors[ihq - 1], nl
+            esf.info.coupling_constants, esf.Q2, kind, flavors[ihq - 1], nl
         )
         asys = [
             -kernels.Kernel(wa["ns"], fonll_cfs.AsyQuark(esf, nl, mu2hq=mu2hq)),
@@ -232,7 +233,7 @@ def generate_heavy_intrinsic_diff(esf, nl, pto_evol):
         k.min_order = 2
     if esf.process == "CC":
         w = kernels.cc_weights(
-            esf.info.coupling_constants, esf.Q2, kind, kernels.flavors[ihq - 1], ihq
+            esf.info.coupling_constants, esf.Q2, kind, flavors[ihq - 1], ihq
         )
         wq = {k: v for k, v in w["ns"].items() if abs(k) == ihq}
         if kind == "F3":

--- a/src/yadism/coefficient_functions/heavy/kernels.py
+++ b/src/yadism/coefficient_functions/heavy/kernels.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from .. import kernels
+from ..coupling_constants import flavors
 from ..light.kernels import nc_weights as light_nc_weights
 
 
@@ -29,7 +30,7 @@ def generate(esf, nf, ihq):
     if esf.process == "CC":
         # TODO: use ihq for couplings
         w = kernels.cc_weights(
-            esf.info.coupling_constants, esf.Q2, kind, kernels.flavors[nf], nf
+            esf.info.coupling_constants, esf.Q2, kind, flavors[nf], nf
         )
         return (
             kernels.Kernel(w["ns"], pcs.NonSinglet(esf, nf, m2hq=m2hq)),

--- a/src/yadism/coefficient_functions/intrinsic/kernels.py
+++ b/src/yadism/coefficient_functions/intrinsic/kernels.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from .. import kernels
+from ..coupling_constants import flavors
 
 
 def import_pc_module(kind, process):
@@ -28,7 +29,7 @@ def generate(esf, ihq):
     m2hq = esf.info.m2hq[ihq - 4]
     if esf.process == "CC":
         w = kernels.cc_weights(
-            esf.info.coupling_constants, esf.Q2, kind, kernels.flavors[ihq - 1], ihq
+            esf.info.coupling_constants, esf.Q2, kind, flavors[ihq - 1], ihq
         )
         wq = {k: v for k, v in w["ns"].items() if abs(k) == ihq}
         if kind == "F3":

--- a/src/yadism/coefficient_functions/kernels.py
+++ b/src/yadism/coefficient_functions/kernels.py
@@ -3,6 +3,8 @@ import copy
 import importlib
 from numbers import Number
 
+from .coupling_constants import flavors
+
 
 def import_local(kind, process, sibling):
     """
@@ -104,9 +106,6 @@ class Kernel:
         return self.__class__(
             partons, copy.copy(self.coeff), self.max_order, self.min_order
         )
-
-
-flavors = "duscbt"
 
 
 def cc_weights(coupling_constants, Q2, kind, cc_mask, nf):

--- a/src/yadism/coefficient_functions/light/kernels.py
+++ b/src/yadism/coefficient_functions/light/kernels.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from .. import kernels
+from ..coupling_constants import flavors
 
 
 def import_pc_module(kind, process):
@@ -26,13 +27,13 @@ def generate(esf, nf):
     pcs = import_pc_module(kind, esf.process)
     if esf.process == "CC":
         weights_even = kernels.cc_weights_even(
-            esf.info.coupling_constants, esf.Q2, kind, kernels.flavors[:nf], nf
+            esf.info.coupling_constants, esf.Q2, kind, flavors[:nf], nf
         )
         ns_even = kernels.Kernel(weights_even["ns"], pcs.NonSingletEven(esf, nf))
         g = kernels.Kernel(weights_even["g"], pcs.Gluon(esf, nf))
         s = kernels.Kernel(weights_even["s"], pcs.Singlet(esf, nf))
         weights_odd = kernels.cc_weights_odd(
-            esf.info.coupling_constants, esf.Q2, kind, kernels.flavors[:nf], nf
+            esf.info.coupling_constants, esf.Q2, kind, flavors[:nf], nf
         )
         ns_odd = kernels.Kernel(weights_odd["ns"], pcs.NonSingletOdd(esf, nf))
         return (ns_even, g, s, ns_odd)

--- a/src/yadmark/benchmark/external/apfel_utils.py
+++ b/src/yadmark/benchmark/external/apfel_utils.py
@@ -31,6 +31,9 @@ def load_apfel(theory, observables, pdf="ToyLH", use_external_grid=False):
     apfel.SetPolarizationDIS(observables.get("PolarizationDIS", 0))
     apfel.SetProjectileDIS(observables.get("ProjectileDIS", "electron"))
     apfel.SetTargetDIS(observables.get("TargetDIS", "proton"))
+    charge = observables.get("NCPositivityCharge")
+    if charge is not None:
+        apfel.SelectCharge(charge)
 
     # apfel initialization for DIS
     apfel.InitializeAPFEL_DIS()

--- a/src/yadmark/data/db.py
+++ b/src/yadmark/data/db.py
@@ -15,3 +15,4 @@ class Observable(Base):
     observables = Column(Text)
     prDIS = Column(Text)
     TargetDIS = Column(Text)
+    NCPositivityCharge = Column(Text)

--- a/src/yadmark/data/observables.py
+++ b/src/yadmark/data/observables.py
@@ -14,6 +14,7 @@ default_card = dict(
     PolarizationDIS=0,
     PropagatorCorrection=0,
     TargetDIS="proton",
+    NCPositivityCharge=None,
     observables={},
 )
 default_card = dict(sorted(default_card.items()))

--- a/tests/yadism/cf/test_coupling_constants.py
+++ b/tests/yadism/cf/test_coupling_constants.py
@@ -16,7 +16,11 @@ class TestCouplingConstanst:
 
         # EM
         obs_d = dict(
-            projectilePID=11, polarization=0.0, process="EM", propagatorCorrection=0
+            projectilePID=11,
+            polarization=0.0,
+            process="EM",
+            propagatorCorrection=0,
+            nc_pos_charge=None,
         )
         assert coupl.CouplingConstants(th_d, obs_d).get_weight(1, 90, "VA") == 0
         assert coupl.CouplingConstants(th_d, obs_d).get_weight(1, 90, "AV") == 0
@@ -28,6 +32,7 @@ class TestCouplingConstanst:
             polarization=0.0,
             process="NC",
             propagatorCorrection=0.5,
+            nc_pos_charge=None,
         )
         assert coupl.CouplingConstants(th_d, obs_d).get_weight(1, 0, "VA") == 0
         assert coupl.CouplingConstants(th_d, obs_d).get_weight(1, 0, "AV") == 0
@@ -38,11 +43,11 @@ class TestCouplingConstanst:
             sin2theta_weak=0.5,
             CKM="0.97428 0.22530 0.003470 0.22520 0.97345 0.041000 0.00862 0.04030 0.999152",
         )
-        obs_d = dict(prDIS="CC", PolarizationDIS=0.0, PropagatorCorrection=0)
-        assert coupl.CouplingConstants.from_dict(th_d, obs_d).get_weight(
-            1, 0, None, cc_mask="b"
-        ) == coupl.CouplingConstants.from_dict(th_d, obs_d).get_weight(
-            1, 0, None, cc_mask="b"
+        obs_d = dict(
+            prDIS="CC",
+            PolarizationDIS=0.0,
+            PropagatorCorrection=0,
+            NCPositivityCharge=None,
         )
         assert coupl.CouplingConstants.from_dict(th_d, obs_d).get_weight(
             1, 0, None, cc_mask="b"
@@ -53,10 +58,49 @@ class TestCouplingConstanst:
         # Unknown
         th_d = dict(sin2theta_weak=1.0)
         obs_d = dict(
-            projectilePID=11, polarization=0.0, process="XX", propagatorCorrection=0
+            projectilePID=11,
+            polarization=0.0,
+            process="XX",
+            propagatorCorrection=0,
+            nc_pos_charge=None,
         )
         with pytest.raises(ValueError, match="Unknown"):
             coupl.CouplingConstants(th_d, obs_d).get_weight(1, 90, "VV")
+
+    def test_pos(self):
+        th_d = dict(sin2theta_weak=1.0)
+
+        # EM
+        obs_d = dict(
+            projectilePID=11,
+            polarization=0.0,
+            process="EM",
+            propagatorCorrection=0,
+            nc_pos_charge="up",
+        )
+        assert coupl.CouplingConstants(th_d, obs_d).get_weight(1, 90.0, "VV") == 0.0
+        assert (
+            coupl.CouplingConstants(th_d, obs_d).get_weight(2, 90.0, "VV") == 4.0 / 9.0
+        )
+        assert coupl.CouplingConstants(th_d, obs_d).get_weight(3, 90.0, "VV") == 0.0
+
+        # must have no effect in CC
+        th_d = dict(
+            sin2theta_weak=0.5,
+            CKM="0.97428 0.22530 0.003470 0.22520 0.97345 0.041000 0.00862 0.04030 0.999152",
+        )
+        obs_d = dict(
+            prDIS="CC",
+            PolarizationDIS=0.0,
+            PropagatorCorrection=0,
+            NCPositivityCharge="up",
+        )
+        assert not np.isclose(
+            coupl.CouplingConstants.from_dict(th_d, obs_d).get_weight(
+                1, 90.0, None, cc_mask="dus"
+            ),
+            0.0,
+        )
 
     def test_from_dict(self):
         sin2tw = 0.5
@@ -66,7 +110,12 @@ class TestCouplingConstanst:
             MZ=MZ,
             CKM="0.97428 0.22530 0.003470 0.22520 0.97345 0.041000 0.00862 0.04030 0.999152",
         )
-        obs_d = dict(PolarizationDIS=0.0, prDIS="EM", PropagatorCorrection=0)
+        obs_d = dict(
+            PolarizationDIS=0.0,
+            prDIS="EM",
+            PropagatorCorrection=0,
+            NCPositivityCharge=None,
+        )
         coupl_const = coupl.CouplingConstants.from_dict(th_d, obs_d)
 
         assert coupl_const.theory_config["MZ2"] == MZ**2
@@ -89,7 +138,11 @@ class TestLeptonicHadronic:
             CKM="0.97428 0.22530 0.003470 0.22520 0.97345 0.041000 0.00862 0.04030 0.999152",
         )
         obs_d = dict(
-            prDIS="EM", projectilePID=11, PolarizationDIS=0.0, PropagatorCorrection=0
+            prDIS="EM",
+            projectilePID=11,
+            PolarizationDIS=0.0,
+            PropagatorCorrection=0,
+            NCPositivityCharge=None,
         )
         coupl_const = coupl.CouplingConstants.from_dict(th_d, obs_d)
 
@@ -104,6 +157,7 @@ class TestLeptonicHadronic:
                 projectilePID=projPID,
                 polarization=0.0,
                 propagatorCorrection=0,
+                nc_pos_charge=None,
             )
             coupl_const = coupl.CouplingConstants(th_d, obs_d)
 
@@ -120,11 +174,19 @@ class TestLeptonicHadronic:
         th_d = dict(sin2theta_weak=1.0)
 
         obs_d_em = dict(
-            process="EM", projectilePID=11, polarization=0.5, propagatorCorrection=0
+            process="EM",
+            projectilePID=11,
+            polarization=0.5,
+            propagatorCorrection=0,
+            nc_pos_charge=None,
         )
         coupl_const_em = coupl.CouplingConstants(th_d, obs_d_em)
         obs_d_ep = dict(
-            process="EM", projectilePID=-11, polarization=-0.5, propagatorCorrection=0
+            process="EM",
+            projectilePID=-11,
+            polarization=-0.5,
+            propagatorCorrection=0,
+            nc_pos_charge=None,
         )
         coupl_const_ep = coupl.CouplingConstants(th_d, obs_d_ep)
 
@@ -139,11 +201,19 @@ class TestLeptonicHadronic:
         th_d = dict(sin2theta_weak=1.0)
 
         obs_d_nu = dict(
-            process="EM", projectilePID=12, polarization=0.7, propagatorCorrection=0
+            process="EM",
+            projectilePID=12,
+            polarization=0.7,
+            propagatorCorrection=0,
+            nc_pos_charge=None,
         )
         coupl_const_nu = coupl.CouplingConstants(th_d, obs_d_nu)
         obs_d_nubar = dict(
-            process="EM", projectilePID=-12, polarization=-0.7, propagatorCorrection=0
+            process="EM",
+            projectilePID=-12,
+            polarization=-0.7,
+            propagatorCorrection=0,
+            nc_pos_charge=None,
         )
         coupl_const_nubar = coupl.CouplingConstants(th_d, obs_d_nubar)
 
@@ -157,7 +227,11 @@ class TestLeptonicHadronic:
     def test_unknown(self):
         th_d = dict(sin2theta_weak=1.0)
         obs_d = dict(
-            process="EM", projectilePID=12, polarization=0.7, propagatorCorrection=0
+            process="EM",
+            projectilePID=12,
+            polarization=0.7,
+            propagatorCorrection=0,
+            nc_pos_charge=None,
         )
         coupl_const = coupl.CouplingConstants(th_d, obs_d)
         with pytest.raises(ValueError, match="Unknown"):
@@ -169,28 +243,28 @@ class TestLeptonicHadronic:
 class TestPropagator:
     def test_cc(self):
         th_d = dict(sin2theta_weak=0.5, MZ2=100, MW2=80**2)
-        obs_d = dict(process="EM", propagatorCorrection=0)
+        obs_d = dict(process="EM", propagatorCorrection=0, nc_pos_charge=None)
         coupl_const = coupl.CouplingConstants(th_d, obs_d)
 
         assert coupl_const.propagator_factor("WW", 0.0) == 0.0
 
     def test_pure_em(self):
         th_d = dict(sin2theta_weak=0.5, MZ2=80, MW2=100**2)
-        obs_d = dict(process="EM", propagatorCorrection=0)
+        obs_d = dict(process="EM", propagatorCorrection=0, nc_pos_charge=None)
         coupl_const = coupl.CouplingConstants(th_d, obs_d)
 
         assert coupl_const.propagator_factor("phph", 91.2) == 1.0
 
     def test_nc_interference(self):
         th_d = dict(sin2theta_weak=0.5, MZ2=100, MW2=80**2)
-        obs_d = dict(process="EM", propagatorCorrection=0)
+        obs_d = dict(process="EM", propagatorCorrection=0, nc_pos_charge=None)
         coupl_const = coupl.CouplingConstants(th_d, obs_d)
 
         assert coupl_const.propagator_factor("phZ", 0.0) == 0.0
 
     def test_pure_z(self):
         th_d = dict(sin2theta_weak=0.5, MZ2=80, MW2=100**2)
-        obs_d = dict(process="EM", propagatorCorrection=0)
+        obs_d = dict(process="EM", propagatorCorrection=0, nc_pos_charge=None)
         coupl_const = coupl.CouplingConstants(th_d, obs_d)
 
         assert coupl_const.propagator_factor(
@@ -199,7 +273,7 @@ class TestPropagator:
 
     def test_unknown(self):
         th_d = dict(sin2theta_weak=0.5, MZ2=91.1876)
-        obs_d = dict(process="EM", propagatorCorrection=0)
+        obs_d = dict(process="EM", propagatorCorrection=0, nc_pos_charge=None)
         coupl_const = coupl.CouplingConstants(th_d, obs_d)
 
         with pytest.raises(ValueError, match="Unknown"):

--- a/tests/yadism/test_runner.py
+++ b/tests/yadism/test_runner.py
@@ -106,6 +106,7 @@ class TestRunner:
             ProjectileDIS="electron",
             PolarizationDIS=0.0,
             PropagatorCorrection=0.0,
+            NCPositivityCharge=None,
             observables={
                 "F2_charm": [dict(x=0.1, Q2=10.0)],
                 "XSCHORUSCC": [dict(x=0.1, y=0.5, Q2=10.0)],


### PR DESCRIPTION
- this is the yadism part of the DIS positivity implementation - it follows the [previous apfel implementation](https://github.com/scarrazza/apfel/blob/master/src/DIS/SelectCharge.f), i.e. it is only active in the NC sector (as for CC the situation is more complicated due to CKM)
- next in line is a accompanying PR in runcardsrunner
- @scarlehoff or @cschwan: could you please remind me how to get the actual settings? (from the old FK table?) i.e. we need `F2up(x=?,Q2=?)`